### PR TITLE
fix: Resolve database migration crash on launch

### DIFF
--- a/app/src/main/java/com/faharix/zappo/data/Note.kt
+++ b/app/src/main/java/com/faharix/zappo/data/Note.kt
@@ -17,7 +17,7 @@ data class Note(
     val isDeleted: Boolean = false,
     val createdAt: Date = Date(),
     val modifiedAt: Date = Date(),
-    val imageUris: List<String> = emptyList(),
+    val imageUris: List<String>? = null,
     val textFormatting: String? = null,
     val reminderDateTime: Long? = null,
     val reminderRecurrence: String? = null


### PR DESCRIPTION
The application was crashing on launch due to an IllegalStateException caused by a schema mismatch during database migration. Room expected the `imageUris` column in the `notes` table to be non-nullable, while the migration created it as nullable.

This commit fixes the issue by:
- Modifying the `imageUris` field in the `Note.kt` data class to be nullable (`List<String>?`), aligning it with the database schema and common use cases where a note may not have images.
- Verifying that other new fields (`textFormatting`, `reminderDateTime`, `reminderRecurrence`) in `Note.kt` have appropriate nullability consistent with the database.
- Reviewing and confirming that the existing database migrations in `AppDatabase.kt` are compatible with the updated `Note.kt` entity.

These changes ensure that Room can correctly validate the database schema after migration, preventing the crash.