### PR TITLE
feat: Implement audio recording and playback for notes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+
     <application
         android:name=".ZappoApplication"
         android:allowBackup="true"

--- a/app/src/main/java/com/faharix/zappo/MainActivity.kt
+++ b/app/src/main/java/com/faharix/zappo/MainActivity.kt
@@ -71,11 +71,11 @@ class MainActivity : ComponentActivity() {
                             EditNoteScreen(
                                 note = note,
                                 contentType = if (note?.isTask == true) ContentType.TASKS else ContentType.NOTES,
-                                onSaveNote = { title, content, folder, isTask, isCompleted, dueDate, imageUris, textFormatting, reminderDateTime, reminderRecurrence ->
+                                onSaveNote = { title, content, folder, isTask, isCompleted, dueDate, imageUris, textFormatting, reminderDateTime, reminderRecurrence, audioFilePath ->
                                     if (noteId == -1) {
-                                        notesViewModel.addNote(title, content, folder, isTask, isCompleted, dueDate, imageUris, textFormatting, reminderDateTime, reminderRecurrence)
+                                        notesViewModel.addNote(title, content, folder, isTask, isCompleted, dueDate, imageUris, textFormatting, reminderDateTime, reminderRecurrence, audioFilePath)
                                     } else {
-                                        notesViewModel.updateNote(noteId, title, content, folder, isTask, isCompleted, dueDate, imageUris, textFormatting, reminderDateTime, reminderRecurrence)
+                                        notesViewModel.updateNote(noteId, title, content, folder, isTask, isCompleted, dueDate, imageUris, textFormatting, reminderDateTime, reminderRecurrence, audioFilePath)
                                     }
                                     navController.popBackStack()
                                 },

--- a/app/src/main/java/com/faharix/zappo/data/AppDatabase.kt
+++ b/app/src/main/java/com/faharix/zappo/data/AppDatabase.kt
@@ -8,7 +8,7 @@ import androidx.room.TypeConverters
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
-@Database(entities = [Note::class], version = 5) // Version incremented to 5
+@Database(entities = [Note::class], version = 6) // Version incremented to 6
 @TypeConverters(Converters::class) // Pour les conversions de Date
 abstract class AppDatabase : RoomDatabase() {
     abstract fun noteDao(): NoteDao
@@ -51,6 +51,13 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        // Migration from version 5 to 6: Add audioFilePath column
+        private val MIGRATION_5_6 = object : Migration(5, 6) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE notes ADD COLUMN audioFilePath TEXT") // Storing String? as TEXT, allows NULL
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -58,7 +65,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "notes_database"
                 )
-                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5) // Added MIGRATION_4_5
+                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6) // Added MIGRATION_5_6
                     .build()
                 INSTANCE = instance
                 instance

--- a/app/src/main/java/com/faharix/zappo/data/Note.kt
+++ b/app/src/main/java/com/faharix/zappo/data/Note.kt
@@ -20,5 +20,6 @@ data class Note(
     val imageUris: List<String>? = null,
     val textFormatting: String? = null,
     val reminderDateTime: Long? = null,
-    val reminderRecurrence: String? = null
+    val reminderRecurrence: String? = null,
+    val audioFilePath: String? = null
 )

--- a/app/src/main/java/com/faharix/zappo/repository/NoteRepository.kt
+++ b/app/src/main/java/com/faharix/zappo/repository/NoteRepository.kt
@@ -30,7 +30,8 @@ class NoteRepository @Inject constructor(private val noteDao: NoteDao) {
         imageUris: List<String> = emptyList(),
         textFormatting: String? = null,
         reminderDateTime: Long? = null,
-        reminderRecurrence: String? = null
+        reminderRecurrence: String? = null,
+        audioFilePath: String? = null
     ): Long {
         val note = Note(
             title = title,
@@ -44,7 +45,8 @@ class NoteRepository @Inject constructor(private val noteDao: NoteDao) {
             imageUris = imageUris,
             textFormatting = textFormatting,
             reminderDateTime = reminderDateTime,
-            reminderRecurrence = reminderRecurrence
+            reminderRecurrence = reminderRecurrence,
+            audioFilePath = audioFilePath
         )
         return noteDao.insertNote(note)
     }
@@ -60,7 +62,8 @@ class NoteRepository @Inject constructor(private val noteDao: NoteDao) {
         imageUris: List<String> = emptyList(),
         textFormatting: String? = null,
         reminderDateTime: Long? = null,
-        reminderRecurrence: String? = null
+        reminderRecurrence: String? = null,
+        audioFilePath: String? = null
     ) {
         val note = noteDao.getNoteById(id)
         note?.let {
@@ -75,7 +78,8 @@ class NoteRepository @Inject constructor(private val noteDao: NoteDao) {
                 imageUris = imageUris,
                 textFormatting = textFormatting,
                 reminderDateTime = reminderDateTime,
-                reminderRecurrence = reminderRecurrence
+                reminderRecurrence = reminderRecurrence,
+                audioFilePath = audioFilePath
             )
             noteDao.updateNote(updatedNote)
         }

--- a/app/src/main/java/com/faharix/zappo/viewmodel/NotesViewModel.kt
+++ b/app/src/main/java/com/faharix/zappo/viewmodel/NotesViewModel.kt
@@ -54,10 +54,11 @@ class NotesViewModel @Inject constructor(
         imageUris: List<String> = emptyList(),
         textFormatting: String? = null,
         reminderDateTime: Long? = null,
-        reminderRecurrence: String? = null
+        reminderRecurrence: String? = null,
+        audioFilePath: String? = null
     ) {
         viewModelScope.launch {
-            repository.insertNote(title, content, folder, isTask, isCompleted, dueDate, imageUris, textFormatting, reminderDateTime, reminderRecurrence)
+            repository.insertNote(title, content, folder, isTask, isCompleted, dueDate, imageUris, textFormatting, reminderDateTime, reminderRecurrence, audioFilePath)
         }
     }
 
@@ -72,10 +73,11 @@ class NotesViewModel @Inject constructor(
         imageUris: List<String> = emptyList(),
         textFormatting: String? = null,
         reminderDateTime: Long? = null,
-        reminderRecurrence: String? = null
+        reminderRecurrence: String? = null,
+        audioFilePath: String? = null
     ) {
         viewModelScope.launch {
-            repository.updateNote(id, title, content, folder, isTask, isCompleted, dueDate, imageUris, textFormatting, reminderDateTime, reminderRecurrence)
+            repository.updateNote(id, title, content, folder, isTask, isCompleted, dueDate, imageUris, textFormatting, reminderDateTime, reminderRecurrence, audioFilePath)
         }
     }
 
@@ -91,9 +93,10 @@ class NotesViewModel @Inject constructor(
                     !note.isCompleted,
                     dueDate = note.dueDate,
                     imageUris = note.imageUris,
-                    textFormatting = note.textFormatting, // Preserve existing textFormatting
-                    reminderDateTime = note.reminderDateTime, // Preserve existing reminderDateTime
-                    reminderRecurrence = note.reminderRecurrence // Preserve existing reminderRecurrence
+                    textFormatting = note.textFormatting,
+                    reminderDateTime = note.reminderDateTime,
+                    reminderRecurrence = note.reminderRecurrence,
+                    audioFilePath = note.audioFilePath // Preserve existing audioFilePath
                 )
             }
         }

--- a/app/src/test/java/com/faharix/zappo/viewmodel/NotesViewModelTest.kt
+++ b/app/src/test/java/com/faharix/zappo/viewmodel/NotesViewModelTest.kt
@@ -67,18 +67,19 @@ class NotesViewModelTest {
         val textFormatting = "{\"bold\": true}"
         val reminderDateTime = System.currentTimeMillis()
         val reminderRecurrence = "Daily"
+        val audioFilePath = "path/to/audio.mp3"
 
         // When
         viewModel.addNote(
             title, content, folder, isTask, isCompleted, dueDate,
-            imageUris, textFormatting, reminderDateTime, reminderRecurrence
+            imageUris, textFormatting, reminderDateTime, reminderRecurrence, audioFilePath
         )
         testDispatcher.scheduler.advanceUntilIdle() // Ensure coroutine launched by viewModelScope completes
 
         // Then
         verify(mockRepository).insertNote(
             title, content, folder, isTask, isCompleted, dueDate,
-            imageUris, textFormatting, reminderDateTime, reminderRecurrence
+            imageUris, textFormatting, reminderDateTime, reminderRecurrence, audioFilePath
         )
     }
 
@@ -96,18 +97,19 @@ class NotesViewModelTest {
         val textFormatting = "{\"italic\": true}"
         val reminderDateTime = System.currentTimeMillis() + 10000
         val reminderRecurrence = "Weekly"
+        val audioFilePath = "path/to/updated_audio.mp3"
 
         // When
         viewModel.updateNote(
             noteId, title, content, folder, isTask, isCompleted, dueDate,
-            imageUris, textFormatting, reminderDateTime, reminderRecurrence
+            imageUris, textFormatting, reminderDateTime, reminderRecurrence, audioFilePath
         )
         testDispatcher.scheduler.advanceUntilIdle()
 
         // Then
         verify(mockRepository).updateNote(
             noteId, title, content, folder, isTask, isCompleted, dueDate,
-            imageUris, textFormatting, reminderDateTime, reminderRecurrence
+            imageUris, textFormatting, reminderDateTime, reminderRecurrence, audioFilePath
         )
     }
 
@@ -119,6 +121,7 @@ class NotesViewModelTest {
         val originalTextFormatting = "{\"bold\": true, \"color\": \"#FF0000\"}"
         val originalReminderDateTime = System.currentTimeMillis()
         val originalReminderRecurrence = "Daily"
+        val originalAudioFilePath = "path/to/original_audio.mp3"
 
         val testNote = Note(
             id = 1,
@@ -132,6 +135,7 @@ class NotesViewModelTest {
             textFormatting = originalTextFormatting,
             reminderDateTime = originalReminderDateTime,
             reminderRecurrence = originalReminderRecurrence,
+            audioFilePath = originalAudioFilePath,
             createdAt = Date(),
             modifiedAt = Date()
         )
@@ -153,7 +157,8 @@ class NotesViewModelTest {
             originalImageUris,
             originalTextFormatting,
             originalReminderDateTime,
-            originalReminderRecurrence
+            originalReminderRecurrence,
+            originalAudioFilePath
         )
     }
 }


### PR DESCRIPTION
This commit introduces the ability for you to record, attach, play, and delete audio notes within the application.

Key changes include:

- **Data Model**:
    - Added `audioFilePath: String?` to the `Note.kt` data class to store the URI of the audio file.

- **UI (`EditNoteScreen.kt` मेजर)**:
    - Added new `IconButton`s for starting/stopping recording, playing/stopping playback, and deleting audio notes.
    - UI state now manages recording status (`isRecording`) and playback status (`isPlayingAudio`).
    - Audio control icons dynamically update based on state (e.g., play/stop icon).
    - Added a confirmation dialog for deleting audio recordings.

- **Audio Recording (`MediaRecorder`)**:
    - Implemented logic to record audio using `MediaRecorder`.
    - Recordings are saved to the app's internal cache directory.
    - Handles `MediaRecorder` setup, start, stop, reset, and release.
    - Includes basic error handling and resource cleanup via `DisposableEffect`.

- **Audio Playback (`MediaPlayer`)**:
    - Implemented logic to play back recorded audio using `MediaPlayer`.
    - Handles `MediaPlayer` setup, start, stop, and release.
    - Includes `setOnCompletionListener` and `setOnErrorListener`.
    - Manages playback state and resource cleanup.

- **Permissions**:
    - Added runtime permission request for `RECORD_AUDIO` using Accompanist Permissions.
    - Updated `AndroidManifest.xml` to include the `RECORD_AUDIO` permission.

- **ViewModel & Repository**:
    - Updated `NotesViewModel` and `NoteRepository` to handle the new `audioFilePath` field in `addNote` and `updateNote` methods.
    - Ensured `audioFilePath` is preserved during operations like `toggleTaskCompletion`.

- **Database**:
    - Incremented database version from 5 to 6.
    - Added `MIGRATION_5_6` to `AppDatabase.kt` to add the `audioFilePath TEXT` column to the `notes` table.

- **Tests**:
    - Updated unit tests in `NotesViewModelTest.kt` to verify the correct handling of the `audioFilePath` field.